### PR TITLE
Don't need to give the private containers a public IP

### DIFF
--- a/service-stacks/private-subnet-public-loadbalancer.yml
+++ b/service-stacks/private-subnet-public-loadbalancer.yml
@@ -99,7 +99,6 @@ Resources:
       DesiredCount: !Ref 'DesiredCount'
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
           SecurityGroups:
             - Fn::ImportValue:
                 !Join [':', [!Ref 'StackName', 'FargateContainerSecurityGroup']]


### PR DESCRIPTION
- The routing works just fine without public IPs for the containers